### PR TITLE
Fix /admin failing to load (error boundary, auth-gate, bounded reads)

### DIFF
--- a/app/admin/error.tsx
+++ b/app/admin/error.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import { RiftWordmark } from "@/components/icons/rift-wordmark";
+
+/**
+ * Route-level error boundary for /admin. Without this, any error thrown while
+ * rendering the dashboard (e.g. the stats query failing) bubbles past React
+ * with no fallback — on mobile Safari that surfaces as a blank "This page
+ * couldn't load" screen. Catching it here keeps the page recoverable.
+ */
+export default function AdminError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[Admin] dashboard failed to load:", error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background px-6 text-center">
+      <RiftWordmark height={16} className="text-foreground" />
+      <p className="text-sm text-muted-foreground">
+        The admin dashboard couldn&apos;t load.
+      </p>
+      <button
+        type="button"
+        onClick={reset}
+        className="rounded-md border border-border bg-card px-4 py-2 text-sm font-medium text-foreground hover:bg-accent"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { useQuery } from "convex/react";
+import {
+  useQuery,
+  Authenticated,
+  Unauthenticated,
+  AuthLoading,
+} from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { formatTokens } from "@/lib/billing/token-display";
 import { RiftWordmark } from "@/components/icons/rift-wordmark";
@@ -25,26 +30,55 @@ function StatCard({ label, value }: { label: string; value: string }) {
   );
 }
 
+function LoadingScreen() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background text-muted-foreground">
+      Loading…
+    </div>
+  );
+}
+
+function NotAuthorized() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-3 bg-background text-center">
+      <RiftWordmark height={16} className="text-foreground" />
+      <p className="text-sm text-muted-foreground">
+        Not authorized. This page is for admins only.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Gate the dashboard on auth state — mirrors the rest of the app — so the
+ * stats query only runs once the user is authenticated. Running it before auth
+ * resolves makes it return null (not authorized) on the first paint.
+ */
 export default function AdminPage() {
+  return (
+    <>
+      <AuthLoading>
+        <LoadingScreen />
+      </AuthLoading>
+      <Unauthenticated>
+        <NotAuthorized />
+      </Unauthenticated>
+      <Authenticated>
+        <AdminDashboard />
+      </Authenticated>
+    </>
+  );
+}
+
+function AdminDashboard() {
   const stats = useQuery(api.admin.getAdminStats);
 
   if (stats === undefined) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-background text-muted-foreground">
-        Loading…
-      </div>
-    );
+    return <LoadingScreen />;
   }
 
   if (stats === null) {
-    return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-3 bg-background text-center">
-        <RiftWordmark height={16} className="text-foreground" />
-        <p className="text-sm text-muted-foreground">
-          Not authorized. This page is for admins only.
-        </p>
-      </div>
-    );
+    return <NotAuthorized />;
   }
 
   return (

--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -16,9 +16,20 @@ export async function isAdminUser(ctx: QueryCtx): Promise<boolean> {
 }
 
 /**
+ * Upper bound on how many documents we pull from any single table. A Convex
+ * query that reads too many documents (or too many bytes) throws and the whole
+ * dashboard fails to load. Capping each read keeps the page resilient as the
+ * tables grow; the headline numbers stay exact until a table exceeds the cap,
+ * at which point they read as "at least this many" rather than crashing.
+ */
+const MAX_ROWS_PER_TABLE = 4000;
+const MAX_CHAT_ROWS = 3000;
+
+/**
  * Admin dashboard stats. Returns null for non-admins (the UI treats null as
- * "not authorized"). Reads full tables — fine at current scale; revisit with
- * aggregates if the user base grows large.
+ * "not authorized"). Reads are capped (see MAX_ROWS_PER_TABLE) so the query
+ * can't exceed Convex's per-query limits; revisit with aggregates if the user
+ * base grows beyond those caps.
  */
 export const getAdminStats = query({
   args: {},
@@ -48,10 +59,13 @@ export const getAdminStats = query({
     }
 
     const [users, revenueEvents, balances, chats] = await Promise.all([
-      ctx.db.query("users").collect(),
-      ctx.db.query("revenue_events").collect(),
-      ctx.db.query("extra_usage").collect(),
-      ctx.db.query("chats").collect(),
+      // Most recent users first — matches the table's sort and keeps the cap
+      // meaningful (we show newest signups when truncated).
+      ctx.db.query("users").order("desc").take(MAX_ROWS_PER_TABLE),
+      ctx.db.query("revenue_events").take(MAX_ROWS_PER_TABLE),
+      ctx.db.query("extra_usage").take(MAX_ROWS_PER_TABLE),
+      // Newest chats first so "last active" stays accurate for active users.
+      ctx.db.query("chats").order("desc").take(MAX_CHAT_ROWS),
     ]);
 
     const revenueByUser = new Map<string, number>();


### PR DESCRIPTION
## Problem

`/admin` could hard-fail on mobile Safari with a blank **"This page couldn't load"** screen. The server renders the page fine (HTTP 200 + "Loading…"), so the failure is client-side: the `getAdminStats` Convex query throws during render and **nothing catches it** (no error boundary), which crashes the React tree / WebKit content process.

## Changes (scoped to the admin feature only)

- **`app/admin/error.tsx`** (new): route-level error boundary so a failed render/query degrades to a recoverable "Try again" screen instead of crashing.
- **`app/admin/page.tsx`**: gate the dashboard on Convex auth state (`AuthLoading` / `Unauthenticated` / `Authenticated`), matching the rest of the app, so the stats query only runs once auth has resolved.
- **`convex/admin.ts`**: cap each table read in `getAdminStats` so the query can't exceed Convex's per-query document/byte limits as the tables grow. Headline numbers stay exact until a table exceeds its cap.

## Verification

- `tsc --noEmit` ✓, `eslint` ✓
- Full test suite: 1217 tests pass ✓
- `next build` ✓ — `/admin` builds as a dynamic route
- Ran the production server locally and confirmed `/admin` returns **HTTP 200** + "Loading…"

## ⚠️ Deploy note

Merging this redeploys the **frontend** via Vercel. If the root cause is that the `getAdminStats` Convex function isn't present in the production Convex backend, you also need to deploy the Convex functions:

```
npx convex deploy
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NatfM9f2Ryke2c9i3p1vCy)_